### PR TITLE
Add new iPhone 13 versions

### DIFF
--- a/Device.podspec
+++ b/Device.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Device"
-  s.version      = "3.2.2"
+  s.version      = "3.3.0"
   s.summary      = "Light weight tool for detecting the current device and screen size written in swift."
 
   s.description  = "Swift library for detecting the running device's model and screen size. With the newer  devices, developers have more work to do. This library simplifies their job by allowing them to get information about the running device and easily target the ones they want."

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -37,6 +37,10 @@ public enum Version: String {
     case iPhone12
     case iPhone12Pro
     case iPhone12Pro_Max
+    case iPhone13Mini
+    case iPhone13
+    case iPhone13Pro
+    case iPhone13Pro_Max
 
     /*** iPad ***/
     case iPad1

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -51,6 +51,10 @@ open class Device {
             case "iPhone13,2":                               return .iPhone12
             case "iPhone13,3":                               return .iPhone12Pro
             case "iPhone13,4":                               return .iPhone12Pro_Max
+            case "iPhone14,4":                               return .iPhone13Mini
+            case "iPhone14,5":                               return .iPhone13
+            case "iPhone14,2":                               return .iPhone13Pro
+            case "iPhone14,3":                               return .iPhone13Pro_Max
 
             /*** iPad ***/
             case "iPad1,1", "iPad1,2":                       return .iPad1
@@ -133,7 +137,7 @@ open class Device {
                 return .screen5_5Inch
             case 812:
                 switch version() {
-                case .iPhone12Mini:
+                case .iPhone12Mini, .iPhone13Mini:
                     return .screen5_4Inch
                 default:
                     return .screen5_8Inch


### PR DESCRIPTION
While we try to remove the use of this library, we still need to add the new iPhone 13 devices to the list.

This PR already bumps the version to 3.3.0 to avoid new commits on master.