### PR TITLE
Add new generation of iPhone (14)

### DIFF
--- a/Device.podspec
+++ b/Device.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Device"
-  s.version      = "3.3.0"
+  s.version      = "3.4.0"
   s.summary      = "Light weight tool for detecting the current device and screen size written in swift."
 
   s.description  = "Swift library for detecting the running device's model and screen size. With the newer  devices, developers have more work to do. This library simplifies their job by allowing them to get information about the running device and easily target the ones they want."

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -41,6 +41,11 @@ public enum Version: String {
     case iPhone13
     case iPhone13Pro
     case iPhone13Pro_Max
+    case iPhoneSE3
+    case iPhone14
+    case iPhone14Plus
+    case iPhone14Pro
+    case iPhone14ProMax
 
     /*** iPad ***/
     case iPad1

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -55,6 +55,11 @@ open class Device {
             case "iPhone14,5":                               return .iPhone13
             case "iPhone14,2":                               return .iPhone13Pro
             case "iPhone14,3":                               return .iPhone13Pro_Max
+            case "iPhone14,6":                               return .iPhoneSE3
+            case "iPhone14,7":                               return .iPhone14
+            case "iPhone14,8":                               return .iPhone14Plus
+            case "iPhone15,2":                               return .iPhone14Pro
+            case "iPhone15,3":                               return .iPhone14ProMax
 
             /*** iPad ***/
             case "iPad1,1", "iPad1,2":                       return .iPad1
@@ -144,6 +149,8 @@ open class Device {
                 }
             case 844:
                 return .screen6_1Inch
+            case 852:
+              return .screen6_1Inch
             case 896:
                 switch version() {
                 case .iPhoneXS_Max, .iPhone11Pro_Max:
@@ -152,6 +159,8 @@ open class Device {
                     return .screen6_1Inch
                 }
             case 926:
+                return .screen6_7Inch
+            case 932:
                 return .screen6_7Inch
             case 1024:
                 switch version() {


### PR DESCRIPTION
Adding the new generation of iPhones, where the 14Pro and the 14ProMax had a slightly different height due to the flexible notch and were marked as `unknownSize`